### PR TITLE
Rust tutorial

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,11 @@ fn main() {
 
 fn move_ownership() {
     println!("-- move_ownership --");
-    // TODO: これはコピーセマンティクスなので例として不適切。
-    let a = 1;
-    let b = a;
+    // 文字列リテラルで宣言すると値はスタックに積まれるため、変数には参照になる。
+    let a = String::from("hello");
+    // これを有効にすると、a -> b に所有権が移動する。
+    //let b = a;
     println!("{}", a);
-    println!("{}", b);
 }
 
 fn reference_check() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 fn main() {
     println!("-- main --");
     move_ownership();
-    reference_check_2();
+    //reference_check_2();
 }
 
 fn move_ownership() {
     println!("-- move_ownership --");
+    // TODO: これはコピーセマンティクスなので例として不適切。
     let a = 1;
     let b = a;
     println!("{}", a);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,31 @@
 fn main() {
-    println!("Hello, world!");
+    println!("-- main --");
+    move_ownership();
+    reference_check_2();
+}
+
+fn move_ownership() {
+    println!("-- move_ownership --");
+    let a = 1;
+    let b = a;
+    println!("{}", a);
+    println!("{}", b);
+}
+
+fn reference_check() {
+    println!("-- reference_check --");
+    let a = 10;               // immutable object
+    let aref1 = &a;           // reference
+    let aref2 = &a;           // reference
+    println!("{}, {}, {}", a, aref1, aref2); // borrow check!! - OK
+}
+
+fn reference_check_2() {
+    println!("-- reference_check_2 --");
+    let mut a = 10;           // mutable object
+    let a_ref1 = &a;          // reference
+    let a_mut_ref1 = &mut a;  // mutable reference
+    let a_mut_ref2 = &mut a;  // mutable refernece
+    *a_mut_ref2 = 20;         // assign
+    println!("{}", a);        // borrow check!! - OK
 }


### PR DESCRIPTION
- move_ownership で、b の参照がエラーにならない？
- reference_check_2 で、*a_mut_ref1 = 20; になるとコンパイルエラーになるのがわかってない。