### PR TITLE
Add no-curses option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,54 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libc"
@@ -39,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "termion"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,8 +101,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "tower_of_rust"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "termion",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 
 [dependencies]
 
+clap = "2.33.3"
 termion = "1.5.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,24 @@
+extern crate clap;
 extern crate termion;
 
 extern crate tower_of_rust;
 
-//use termion::{clear, cursor, style};
+use clap::{Arg, App};
+
+use termion::{clear, cursor, style};
 use tower_of_rust::models::field::Field;
 use tower_of_rust::screen::Screen;
 
 fn main() {
+    let command_args = App::new("A Tower of Rust")
+        .arg(
+            Arg::with_name("debug")
+                .long("debug")
+                .short("d")
+                .help("Don't run the TUI application for debugging with print functions.")
+        )
+        .get_matches();
+
     let mut field = Field::new(25, 9);
 
     field.surround_with_walls();
@@ -31,14 +43,16 @@ fn main() {
         .collect::<Vec<String>>()
         .join("\n");
     
-    println!("{}", output);
-    // TODO: println でデバッグしやすいように、コマンドオプションで出力モードを変更する。
-    // println!("\n{}{}{}{}",
-    //     cursor::Hide,
-    //     clear::All,
-    //     cursor::Goto(1, 1),
-    //     output);
-    // println!("{}{}",
-    //     style::Reset,
-    //     cursor::Show);
+    if command_args.is_present("debug") {
+        println!("{}", output);
+    } else {
+        println!("\n{}{}{}{}",
+            cursor::Hide,
+            clear::All,
+            cursor::Goto(1, 1),
+            output);
+        println!("{}{}",
+            style::Reset,
+            cursor::Show);
+    }
 }


### PR DESCRIPTION
## 😩 Troubleshooting
### Can not use "3.0.0-beta.4"

```
cargo build                              
   Compiling clap v3.0.0-beta.4
error[E0658]: arbitrary expressions in key-value attributes are unstable
 --> /Users/ishii.koujirou/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.0-beta.4/src/lib.rs:8:10
  |
8 | #![doc = include_str!("../README.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #78835 <https://github.com/rust-lang/rust/issues/78835> for more information

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: could not compile `clap`

To learn more, run the command again with --verbose.
```

I downgraded the version to `2.33.3`.
Document = https://docs.rs/clap/2.33.3/clap/