### PR TITLE
Define details of FieldEffect

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,6 @@
 pub mod field;
 pub mod field_effect;
+pub mod field_effect_combination;
 pub mod field_element;
 pub mod field_object;
 pub mod game;

--- a/src/models/field_effect.rs
+++ b/src/models/field_effect.rs
@@ -2,11 +2,14 @@
 pub struct FieldEffect {
     /// It is unique throughout the application.
     id: String,
+    /// It is the number of frames since it was created. Count from 0.
+    number_of_frames: u64,
 }
 impl FieldEffect {
     pub fn new(id: &str) -> Self {
         Self {
             id: id.to_string(),
+            number_of_frames: 0,
         }
     }
     pub fn get_id(&self) -> String {

--- a/src/models/field_effect.rs
+++ b/src/models/field_effect.rs
@@ -2,14 +2,11 @@
 pub struct FieldEffect {
     /// It is unique throughout the application.
     id: String,
-    /// It is the number of frames since it was created. Count from 0.
-    number_of_frames: u64,
 }
 impl FieldEffect {
     pub fn new(id: &str) -> Self {
         Self {
             id: id.to_string(),
-            number_of_frames: 0,
         }
     }
     pub fn get_id(&self) -> String {

--- a/src/models/field_effect.rs
+++ b/src/models/field_effect.rs
@@ -2,6 +2,7 @@
 pub struct FieldEffect {
     /// It is unique throughout the application.
     id: String,
+    // TODO: おそらく衝突したことがある FieldObject の情報を格納する必要がある。
 }
 impl FieldEffect {
     pub fn new(id: &str) -> Self {

--- a/src/models/field_effect_combination.rs
+++ b/src/models/field_effect_combination.rs
@@ -1,12 +1,21 @@
+use crate::types::{FieldElementPosition, FieldObjectLocation};
+
+// TODO: 少なくとも、FieldObject の生成 -> 移動 -> 衝突で消滅 or 時間で消滅 の遷移が定義できないといけない。
+
+
 #[derive(Debug)]
 pub struct FieldEffectCombination {
     /// It is the number of frames since it was created. Count from 0.
     number_of_frames: u64,
+    transitions: Vec<FieldObjectLocation>,
+    starting_point: FieldElementPosition,
 }
 impl FieldEffectCombination {
-    pub fn new() -> Self {
+    pub fn new(starting_point: FieldElementPosition) -> Self {
         Self {
+            starting_point,
             number_of_frames: 0,
+            transitions: vec![],
         }
     }
 }

--- a/src/models/field_effect_combination.rs
+++ b/src/models/field_effect_combination.rs
@@ -4,7 +4,6 @@ use crate::enums::{FourDirection};
 use crate::id_generator::IdGenerator;
 use crate::types::{FieldElementPosition, FieldEffectLocation, XYVector};
 
-
 // TODO: 少なくとも、FieldObject の生成 -> 移動 -> 衝突で消滅 or 時間で消滅 の遷移が定義できないといけない。
 
 #[derive(Debug)]
@@ -33,7 +32,8 @@ pub enum TransitionKind {
 #[derive(Debug)]
 pub struct FieldEffectCombination {
     pub direction: FourDirection,
-    pub id_map: HashMap<u32, FieldEffectLocation>,
+    /// It means something like this: `<inner_field_object_id, (outer_field_object_id, Option<FieldElementPosition exists when this is placed>)>`.
+    pub id_map: HashMap<u32, (String, Option<FieldElementPosition>)>,
     /// It is the number of frames since it was created. Count from 0.
     pub number_of_frames: u64,
     pub starting_point: FieldElementPosition,
@@ -41,7 +41,7 @@ pub struct FieldEffectCombination {
 }
 impl FieldEffectCombination {
     // TODO: 多くの動きが設定できるようにする。
-    pub fn new(id_generator: IdGenerator, starting_point: FieldElementPosition, direction: FourDirection) -> Self {
+    pub fn new(id_generator: &mut IdGenerator, starting_point: FieldElementPosition, direction: FourDirection) -> Self {
         let transitions: Vec<TransitionKind> = vec![
             TransitionKind::Create {
                 inner_field_effect_id: 1,
@@ -60,18 +60,33 @@ impl FieldEffectCombination {
             },
         ];
 
-        // TODO: Create を拾って、外向けの FieldEffect 用の id を生成する。
-
-        let mut id_map: HashMap<u32, FieldEffectLocation> = HashMap::new();
         Self {
-            id_map: id_map,
+            id_map: Self::create_id_map_from_transitions(id_generator, &transitions),
             starting_point,
             direction,
             number_of_frames: 0,
             transitions,
         }
     }
-    fn prepare_field_effect_ids() -> Vec<String> {
-        vec![]
+    fn create_id_map_from_transitions(
+        id_generator: &mut IdGenerator, transitions: &Vec<TransitionKind>
+    ) -> HashMap<u32, (String, Option<FieldElementPosition>)> {
+        let mut inner_ids: Vec<u32> = vec![];
+        for transition in transitions.iter() {
+            match transition {
+                // TODO: 構造体を含むパターンマッチの時に、ここへ使うフィールドだけ記述したい。
+                TransitionKind::Create {inner_field_effect_id, number_of_frames: _, vector: _} => {
+                    if !inner_ids.iter().any(|e| e == inner_field_effect_id) {
+                        inner_ids.push(inner_field_effect_id.clone());
+                    }
+                },
+                _ => {},
+            }
+        }
+        let mut id_map = HashMap::new();
+        for inner_id in inner_ids.iter() {
+            id_map.insert(inner_id.clone(), (id_generator.generate_for_field_effect(), None));
+        }
+        id_map
     }
 }

--- a/src/models/field_effect_combination.rs
+++ b/src/models/field_effect_combination.rs
@@ -1,0 +1,12 @@
+#[derive(Debug)]
+pub struct FieldEffectCombination {
+    /// It is the number of frames since it was created. Count from 0.
+    number_of_frames: u64,
+}
+impl FieldEffectCombination {
+    pub fn new() -> Self {
+        Self {
+            number_of_frames: 0,
+        }
+    }
+}

--- a/src/models/field_effect_combination.rs
+++ b/src/models/field_effect_combination.rs
@@ -1,21 +1,77 @@
-use crate::types::{FieldElementPosition, FieldObjectLocation};
+use std::collections::HashMap;
+
+use crate::enums::{FourDirection};
+use crate::id_generator::IdGenerator;
+use crate::types::{FieldElementPosition, FieldEffectLocation, XYVector};
+
 
 // TODO: 少なくとも、FieldObject の生成 -> 移動 -> 衝突で消滅 or 時間で消滅 の遷移が定義できないといけない。
 
+#[derive(Debug)]
+pub enum TransitionKind {
+    // TODO: FieldEffect の種類を指定できるようにする。
+    // TODO: 生成済みの FieldEffect を条件に生成できるようにする。
+    Create {
+        inner_field_effect_id: u32,
+        number_of_frames: u64,
+        /// A vector to determine the location of the destination.
+        /// 
+        /// Set the vector for the upward pointing case.
+        vector: XYVector,
+    },
+    // TODO: 衝突時の挙動。消滅したりしなかったりする。
+    Move {
+        inner_field_effect_id: u32,
+        number_of_frames: u64,
+        /// A vector indicating the destination.
+        /// 
+        /// Set the vector for the upward pointing case.
+        vector: XYVector,
+    },
+}
 
 #[derive(Debug)]
 pub struct FieldEffectCombination {
+    pub direction: FourDirection,
+    pub id_map: HashMap<u32, FieldEffectLocation>,
     /// It is the number of frames since it was created. Count from 0.
-    number_of_frames: u64,
-    transitions: Vec<FieldObjectLocation>,
-    starting_point: FieldElementPosition,
+    pub number_of_frames: u64,
+    pub starting_point: FieldElementPosition,
+    pub transitions: Vec<TransitionKind>,
 }
 impl FieldEffectCombination {
-    pub fn new(starting_point: FieldElementPosition) -> Self {
+    // TODO: 多くの動きが設定できるようにする。
+    pub fn new(id_generator: IdGenerator, starting_point: FieldElementPosition, direction: FourDirection) -> Self {
+        let transitions: Vec<TransitionKind> = vec![
+            TransitionKind::Create {
+                inner_field_effect_id: 1,
+                number_of_frames: 1,
+                vector: (0, 0),
+            },
+            TransitionKind::Move {
+                inner_field_effect_id: 1,
+                number_of_frames: 3,
+                vector: (0, -1),
+            },
+            TransitionKind::Move {
+                inner_field_effect_id: 1,
+                number_of_frames: 5,
+                vector: (0, -1),
+            },
+        ];
+
+        // TODO: Create を拾って、外向けの FieldEffect 用の id を生成する。
+
+        let mut id_map: HashMap<u32, FieldEffectLocation> = HashMap::new();
         Self {
+            id_map: id_map,
             starting_point,
+            direction,
             number_of_frames: 0,
-            transitions: vec![],
+            transitions,
         }
+    }
+    fn prepare_field_effect_ids() -> Vec<String> {
+        vec![]
     }
 }

--- a/src/models/field_effect_combination.rs
+++ b/src/models/field_effect_combination.rs
@@ -10,12 +10,14 @@ const MAX_NUMBER_OF_FRAMES: u64 = std::u64::MAX;
 
 #[derive(Debug)]
 pub enum TransitionKind {
+    // TODO: Move 相当の衝突時の挙動。消滅したりしなかったりする。
     // TODO: FieldEffect の種類を指定できるようにする。
     // TODO: 生成済みの FieldEffect を条件に生成できるようにする。
+    // TODO: 出来れば、同じ衝突履歴を共有する FieldEffect 群を設定したい。移動する範囲攻撃を一人に対して1回だけ衝突させたい時用に。
     Create {
         active_frame: u64,
         inner_field_effect_id: u32,
-        /// A vector to determine the location of the destination.
+        /// A vector to determine the destination from the starting point.
         /// 
         /// Set the vector for the upward pointing case.
         vector: XYVector,

--- a/src/models/field_effect_combination.rs
+++ b/src/models/field_effect_combination.rs
@@ -5,8 +5,6 @@ use crate::enums::{FourDirection};
 use crate::id_generator::IdGenerator;
 use crate::types::{FieldElementPosition, XYVector};
 
-// TODO: 少なくとも、FieldObject の生成 -> 移動 -> 衝突で消滅 or 時間で消滅 の遷移が定義できないといけない。
-
 // TODO: どこかにまとめる。
 const MAX_NUMBER_OF_FRAMES: u64 = std::u64::MAX;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,3 +23,8 @@ pub type FieldElementPosition = (u32, u32);
 /// 
 /// It consists of (`FieldElementPosition`, id_of_field_object).
 pub type FieldObjectLocation = (FieldElementPosition, String);
+
+/// A location of a `FieldEffect`.
+/// 
+/// It consists of (`FieldElementPosition`, id_of_field_effect).
+pub type FieldEffectLocation = (FieldElementPosition, String);


### PR DESCRIPTION
## 👉  1 フレーム内の処理順序

- プレイヤーの操作により `FieldEffectCombination` を生成することがある。
- 敵により `FieldEffectCombination` を生成することがある。
- `FieldEffectCombination` が `transitions` の設定に従って `FieldEffect` の生成・移動・削除を行う。
- `FieldEffectCombination` の実行が終了していれば削除する。
- `FieldEffect` と `FieldObject` が同マスに存在しているとき、双方へ状態変化を行う。
  - `FieldEffect` の効果による状態変化を `FieldObject` へ反映する。
  - `FieldEffect` へ衝突した履歴を記録する。
    - （衝突したことにより `FieldEffect` を即座に削除してしまうと、例えば貫通する攻撃などが表現できなくなるので NG）
    - （また、ここで `FieldEffect` を消すと描画上は 1 フレームも存在しないことになる。おそらく生成直後で衝突した `FieldEffect` も 1 フレームだけ描画される方がそれっぽくなる。）
- `FieldObject` の時間経過に伴う状態変化を行う。