### PR TITLE
Set rust-version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: '1.53.0'
+          toolchain: '1.68.0'
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2018"
 rust-version = "1.68"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap = { version = "4.1.11", features = ["derive"] }
 rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower_of_rust"
 version = "0.1.0"
 edition = "2018"
+rust-version = "1.68"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## 🤔 そもそも `actions-rs/toolchain@v1` のバージョン指定が有効になってない

この PR の前から `actions-rs/toolchain@v1` は 1.68 をインストールしていたので、 ffa46fc242d45699553336209562e8afcb1aa4ee は意味がない。
https://github.com/kjirou/tower_of_rust/actions/runs/4495910711/jobs/7910044248

これはこのままにして、v2 が出ているのでそちらに書き換えることを行う。