### PR TITLE
Update run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,3 +22,8 @@ jobs:
           toolchain: '1.68.0'
           command: test
           args: -- --nocapture
+      - uses: actions-rs/cargo@v1
+        with:
+          toolchain: '1.68.0'
+          command: run
+          args: -- --debug

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,7 @@
 on: [push]
 jobs:
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       # The following settings are copied from https://github.com/actions/cache/blob/main/examples.md#rust---cargo .

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,5 +19,6 @@ jobs:
           toolchain: '1.68.0'
       - uses: actions-rs/cargo@v1
         with:
+          toolchain: '1.68.0'
           command: test
           args: -- --nocapture

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,7 @@
-name: Run tests
 on: [push]
 jobs:
   run-tests:
     runs-on: ubuntu-20.04
-    name: Run tests
     steps:
       - uses: actions/checkout@v2
       # The following settings are copied from https://github.com/actions/cache/blob/main/examples.md#rust---cargo .

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,12 +17,14 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: '1.68.0'
-      - uses: actions-rs/cargo@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
         with:
           toolchain: '1.68.0'
           command: test
           args: -- --nocapture
-      - uses: actions-rs/cargo@v1
+      - name: Run app with debugging mode
+        uses: actions-rs/cargo@v1
         with:
           toolchain: '1.68.0'
           command: run


### PR DESCRIPTION
## 👈  Rust のツール群を意図したバージョンで実行するために

- OS にそもそもインストールされていて、普通はそっちを使ってしまうよう。
- バージョンを固定したかったら、`actions-rs/toolchain` で用意したものを `actions-rs/cargo` で呼び出す流れで設定する。
- 実際に `actions-rs/cargo` で呼び出されているものがそのバージョンになっているかの確認が難しかったが、`'1.67.0'` を指定したら、[`rust-version = "1.68"`](https://github.com/kjirou/tower_of_rust/blob/9696939d64cfc9336ebb9a31e0e3030b9efe288c/Cargo.toml#L5) の制約で[失敗したので](https://github.com/kjirou/tower_of_rust/actions/runs/4506770206/jobs/7933904433)多分大丈夫そう。